### PR TITLE
Change difficulty based on party size

### DIFF
--- a/src/components/AddPlayer/AddPlayerCont.tsx
+++ b/src/components/AddPlayer/AddPlayerCont.tsx
@@ -1,9 +1,10 @@
 import { SelectChangeEvent } from "@mui/material";
-import { useState } from "react";
+import { useState,useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { AppDispatch } from "../../app/store";
 import { addClassToClassList, selectClassList, selectSelectedClass } from "../../features/classSearchSlice";
-import { addPlayer, selectLevels } from "../../features/playersSlice";
+import { calcEncoutnerXP } from "../../features/encounterSlice";
+import { addPlayer, selectLevels, selectPlayers } from "../../features/playersSlice";
 import AddPlayerComp from "./AddPlayerComp";
 
 const AddPlayerCont = () =>{
@@ -16,6 +17,13 @@ const AddPlayerCont = () =>{
 
     const [playerLevel, setPlayerLevel] = useState('');
     const [playerName, setPlayerName] = useState('');
+
+    const players = useSelector(selectPlayers);
+
+
+    useEffect(() =>{
+        dispatch(calcEncoutnerXP(players.length))
+    },[players.length,dispatch])
 
     const handleLevelChange = (event: SelectChangeEvent) => {
         setPlayerLevel(event.target.value)
@@ -34,6 +42,8 @@ const AddPlayerCont = () =>{
         setPlayerName('');
         setPlayerLevel('');
     }
+
+    
         
     
     return(

--- a/src/components/InfoDrawer/InfoDrawerComp.tsx
+++ b/src/components/InfoDrawer/InfoDrawerComp.tsx
@@ -73,7 +73,8 @@ const InfoDrawerComp = ({open,color,toggleDrawer}:InfoDrawerCompProps) => {
                   <li>Hard:300 XP</li>
                   <li>Deadly:400 XP</li>
                 </ul>
-                If these adventures are going against 3 Goblins with a total Monster XP value of 300 then the difficulty of the encounter would be Hard since our player Hard XP Threshold is 300.  
+                <Typography component={'p'} sx={{marginY:1}}>If these adventures are going against 3 Goblins with a total Monster XP value of 300 then the difficulty of the encounter would be Hard since our player Hard XP Threshold is 300.</Typography>
+                <Typography component={'p'} sx={{fontStyle:'italic'}}>Please note, the size of the party will affect the encounter XP. The guidelines were originally created for a party between 3-5 players. If a party has less than 3 players the encounter XP multiplier will be higher than normal. If the party has more than 5 players then the encounter XP multiplier will be lower than normal. Please see Party Size under the rules.</Typography>    
               </li>
               <li className="pb-1">You can also view a monster’s stat block by pressing the “View” button on the monster.</li>
             </ol>

--- a/src/components/SearchBar/MonsterSearch.tsx
+++ b/src/components/SearchBar/MonsterSearch.tsx
@@ -11,6 +11,7 @@ import { addMonster, calcEncoutnerXP } from '../../features/encounterSlice';
 
 import { AppDispatch } from '../../app/store';
 import { SelectChangeEvent } from "@mui/material";
+import { selectPlayers } from "../../features/playersSlice";
 
 
 
@@ -26,6 +27,8 @@ const MonsterSearch = () => {
     const loading = open && options.length === 0;
     const [disabled, setDisabled] = useState(false);
     const [label,setLabel] = useState('Monster') 
+
+    const players = useSelector(selectPlayers);
 
     useEffect(() => {
         dispatch(loadMonsterList())
@@ -79,7 +82,7 @@ const MonsterSearch = () => {
             try {
                 const monster = await dispatch(loadMonster(searchedMonster)).unwrap();
                 dispatch(addMonster(monster))
-                dispatch(calcEncoutnerXP())
+                dispatch(calcEncoutnerXP(players.length))
 
             } catch (rejectedValueOrSerializedError) {
                 console.log(rejectedValueOrSerializedError)

--- a/src/components/encounterTable.tsx
+++ b/src/components/encounterTable.tsx
@@ -6,12 +6,14 @@ import { scroller } from "react-scroll";
 import { selectListOfMonsters, removeMonster, calcEncoutnerXP, selectEncounterExp } from "../features/encounterSlice";
 import { setMonsterCardContent, setShowMonsterCard, showMonsterCard } from "../features/MonsterCardSlice";
 import CRToolTip from "./ToolTips/CRToolTip";
+import { selectPlayers } from "../features/playersSlice";
 
 
 const EcounterTable = () => {
     const monsterList = useSelector(selectListOfMonsters);
     const showMonster = useSelector(showMonsterCard);
     const encounterExp = useSelector(selectEncounterExp);
+    const players = useSelector(selectPlayers);
     const dispatch = useDispatch();
 
     const handleViewClick = (index:number) => async (e:any) =>{
@@ -29,7 +31,7 @@ const EcounterTable = () => {
             dispatch(setShowMonsterCard(false))
         }
         dispatch(removeMonster(index))
-        dispatch(calcEncoutnerXP()) // possibly refactor to use useeffect like in playersTable 
+        dispatch(calcEncoutnerXP(players.length))
     }
     
     return (

--- a/src/features/encounterSlice.tsx
+++ b/src/features/encounterSlice.tsx
@@ -29,23 +29,73 @@ const encounterSlice = createSlice({
             state.listOfMonsters.splice(monsterToBeRemoved,1);
            }
         },
-        calcEncoutnerXP(state){
+        calcEncoutnerXP(state,action){
             const initialValue = 0;
             const listOfMonsters = state.listOfMonsters
             const monstersXP = listOfMonsters.map(monster => monster.xp);
             let calcEncounterXP =  monstersXP.reduce((prev,current) => prev + current,initialValue);
-            if (listOfMonsters.length <= 1) {
-                state.encounterExp = calcEncounterXP;
+            const numberOfPlayers = action.payload;
+            // let adjustedNumOfMonsters = listOfMonsters.length;
+            let monsterLevel = 0;
+
+            if(numberOfPlayers <= 2){
+                monsterLevel = 1;
+            }else if (numberOfPlayers >= 6){
+                monsterLevel = -1;
+            }
+
+            // create monster levels
+            if(listOfMonsters.length <= 1)  {
+                monsterLevel += 0;
             } else if(listOfMonsters.length === 2)  {
-                state.encounterExp = calcEncounterXP * 1.5;
+                monsterLevel += 1;
             } else if(listOfMonsters.length <= 6)  {
-                state.encounterExp = calcEncounterXP * 2;
+                monsterLevel += 2;
             } else if(listOfMonsters.length <= 10)  {
-                state.encounterExp = calcEncounterXP * 2.5;
+                monsterLevel += 3;
             } else if(listOfMonsters.length <= 14)  {
-                state.encounterExp = calcEncounterXP * 3;
+                monsterLevel += 4;
             } else if(listOfMonsters.length >= 15)  {
-                state.encounterExp = calcEncounterXP * 4;
+                monsterLevel += 5;
+            }
+            console.log("Monster Level " + monsterLevel);
+
+            // if (listOfMonsters.length <= 1) {
+            //     state.encounterExp = calcEncounterXP;
+            // } else if(listOfMonsters.length === 2)  {
+            //     state.encounterExp = calcEncounterXP * 1.5;
+            // } else if(listOfMonsters.length <= 6)  {
+            //     state.encounterExp = calcEncounterXP * 2;
+            // } else if(listOfMonsters.length <= 10)  {
+            //     state.encounterExp = calcEncounterXP * 2.5;
+            // } else if(listOfMonsters.length <= 14)  {
+            //     state.encounterExp = calcEncounterXP * 3;
+            // } else if(listOfMonsters.length >= 15)  {
+            //     state.encounterExp = calcEncounterXP * 4;
+            // }
+
+            switch (monsterLevel) {
+                case 0:
+                    state.encounterExp = calcEncounterXP;
+                    break;
+                case 1:
+                    state.encounterExp = calcEncounterXP * 1.5;
+                    break;
+                case 2:
+                    state.encounterExp = calcEncounterXP * 2;
+                    break;
+                case 3:
+                    state.encounterExp = calcEncounterXP * 2.5;
+                    break;
+                case 4:
+                    state.encounterExp = calcEncounterXP * 3;
+                    break;
+                case 5:
+                    state.encounterExp = calcEncounterXP * 4;
+                    break;
+
+                default:
+                    break;
             }
             
 


### PR DESCRIPTION
### What 
Fixed a bug where the party size was not being accounted for in the encounter XP.

### Why
The encounter XP will not be more accurate and in compliance with DnD 5e rules.  

### How
There calcencounterXP function now take in the argument of number of players and adjust the encounter monster XP multiplier based on that size. 