### PR TITLE
Cr highest level player

### DIFF
--- a/src/components/AddPlayer/AddPlayerCont.tsx
+++ b/src/components/AddPlayer/AddPlayerCont.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { AppDispatch } from "../../app/store";
 import { addClassToClassList, selectClassList, selectSelectedClass } from "../../features/classSearchSlice";
 import { calcEncoutnerXP } from "../../features/encounterSlice";
-import { addPlayer,selectLevels, selectPlayers } from "../../features/playersSlice";
+import { addPlayer,selectLevels, selectPlayers,selectHighestPlayerLevel,changeHighestPlayerLevel } from "../../features/playersSlice";
 import { changePlayerName, selectInputPlayerName, selectIsPlayerClassEmtpy, selectIsPlayerLevelEmtpy, selectIsPlayerNameEmtpy, togglePlayerClassEmtpy, togglePlayerLevelEmtpy, togglePlayerNameEmpty } from "../../features/searchBarsDrawerSlice";
 import AddPlayerComp from "./AddPlayerComp";
 
@@ -21,6 +21,7 @@ const AddPlayerCont = () =>{
     const IsPlayerLevelEmtpy = useSelector(selectIsPlayerLevelEmtpy);
     const playerName = useSelector(selectInputPlayerName);
     const IsPlayerNameEmtpy = useSelector(selectIsPlayerNameEmtpy);
+    const highestPlayerLevel = useSelector(selectHighestPlayerLevel);
 
     const players = useSelector(selectPlayers);
 
@@ -88,6 +89,11 @@ const AddPlayerCont = () =>{
             if (!isExisting) {
                 dispatch(addClassToClassList(playerClass))
             }
+
+            if (Number(playerLevel) > highestPlayerLevel){
+                dispatch(changeHighestPlayerLevel(Number(playerLevel)))
+            }
+            
             dispatch(changePlayerName(''));
             setPlayerLevel('');
         }

--- a/src/components/MonsterSearch/MonsterSearch.tsx
+++ b/src/components/MonsterSearch/MonsterSearch.tsx
@@ -11,7 +11,7 @@ import { addMonster, calcEncoutnerXP } from '../../features/encounterSlice';
 
 import { AppDispatch } from '../../app/store';
 import { SelectChangeEvent } from "@mui/material";
-import { selectPlayers } from "../../features/playersSlice";
+import { selectHighestPlayerLevel, selectPlayers } from "../../features/playersSlice";
 
 
 
@@ -26,7 +26,8 @@ const MonsterSearch = () => {
     const [open, setOpen] = useState(false);
     const loading = open && options.length === 0;
     const [disabled, setDisabled] = useState(false);
-    const [label,setLabel] = useState('Monster') 
+    const [label,setLabel] = useState('Monster');
+    const highestPlayerLevel = useSelector(selectHighestPlayerLevel); 
 
     const players = useSelector(selectPlayers);
 
@@ -73,11 +74,15 @@ const MonsterSearch = () => {
         }
     },[searchMonsterList.length])
 
-    // useEffect(() => {
-    //     if(cRInpit === ''){
-    //         setDisabled(true)
-    //     }
-    // },[cRInpit])
+    useEffect(() => {
+        if(highestPlayerLevel === 0){
+            setCRInput('');
+        } else{
+            setCRInput(String(highestPlayerLevel));
+        }
+    },[highestPlayerLevel])
+
+    
 
     const handleChange = (e: any,searchedMonster: string | null) => {
         setSearchedMonster(searchedMonster);

--- a/src/components/PlayersTable/PlayersTable.tsx
+++ b/src/components/PlayersTable/PlayersTable.tsx
@@ -53,6 +53,7 @@ const PlayerTable = () => {
         <PlayerTableComp
             listOfPlayers={listOfPlayers}
             editPlayerIndex={editPlayerIndex}
+            highestPlayerLevel={highestPlayerLevel}
             handleRemoveClick={handleRemoveClick}
             handleEditClick={handleEditClick}
         />

--- a/src/components/PlayersTable/PlayersTable.tsx
+++ b/src/components/PlayersTable/PlayersTable.tsx
@@ -1,7 +1,9 @@
 import { useSelector,useDispatch } from "react-redux";
 import { 
+    findNextHighestPlayer,
     removePlayer,
     selectEditPlayerIndex,
+    selectHighestPlayerLevel,
     selectPlayers,
     setTargetEditPlayer, 
 } from "../../features/playersSlice";
@@ -14,13 +16,21 @@ const PlayerTable = () => {
     const listOfPlayers = useSelector(selectPlayers);
     const editPlayerIndex = useSelector(selectEditPlayerIndex);
     const playerClassList = useSelector(selectClassList);
+    const highestPlayerLevel = useSelector(selectHighestPlayerLevel)
 
     // when edtting a player
     const playerIndex = useSelector(selectEditPlayerIndex);
     const edittingPlayerClass = listOfPlayers[playerIndex || 0]?.playerClass;
 
+
     const handleRemoveClick = (index:number) => (e:any) =>{
-        dispatch(removePlayer(index))
+        const playerTobeRemoved = listOfPlayers[index];
+        if(playerTobeRemoved.level === highestPlayerLevel){
+            dispatch(removePlayer(index))
+            dispatch(findNextHighestPlayer())
+        } else{
+            dispatch(removePlayer(index))
+        }
     }
 
     const handleEditClick = (index:number) => (e:any) =>{

--- a/src/components/PlayersTable/PlayersTableComp.tsx
+++ b/src/components/PlayersTable/PlayersTableComp.tsx
@@ -11,13 +11,14 @@ import EditPlayerLevel from "../EditPlayer/editPlayerLevel/editPlayerLevel";
 interface PlayerTableCompProps{
     listOfPlayers:player[];
     editPlayerIndex: number | null;
+    highestPlayerLevel:number;
     handleRemoveClick:(index: number) => (e: any) => void;
     handleEditClick:(index: number) => (e: any) => void;
 
 }
 
 
-const PlayerTableComp = ({listOfPlayers,editPlayerIndex,handleRemoveClick,handleEditClick}:PlayerTableCompProps) => {
+const PlayerTableComp = ({listOfPlayers,editPlayerIndex,highestPlayerLevel,handleRemoveClick,handleEditClick}:PlayerTableCompProps) => {
 
 
     return (
@@ -25,6 +26,14 @@ const PlayerTableComp = ({listOfPlayers,editPlayerIndex,handleRemoveClick,handle
 
             {listOfPlayers.length !== 0 && (
                 <>
+                    <Grid container spacing={1} sx={{marginTop:2}}>
+                        <Grid item xs={12} sm={'auto'}>
+                            <Typography component={'h2'} variant={'h5'}>Players <Typography sx={{ display: { xs: 'none', sm: 'inline' } }} component={'span'} variant={'h5'}>|</Typography></Typography>
+                        </Grid>
+                        <Grid item xs={12} sm={'auto'}>
+                            <Typography component={'h2'} variant={'h5'}>Highest Level: {highestPlayerLevel}</Typography>
+                        </Grid>
+                    </Grid>
                     {listOfPlayers.map((player, index) => (
                         <Paper elevation={4} sx={{ marginY: 2, padding: 1, bgcolor: 'primary.dark', color: 'white' }} key={index}>
                             <Grid container spacing={1} sx={{ alignItems: 'center' }}>

--- a/src/components/SearchBarsDrawer/SearchBarDrawerCont.tsx
+++ b/src/components/SearchBarsDrawer/SearchBarDrawerCont.tsx
@@ -13,7 +13,7 @@ const SearchBarDrawerCont = () => {
 
     useEffect(()=>{
         switch (encounterDifficulty) {
-            case "No Monsters Added":
+            case "No Monsters":
                 setColor("primary")
                 break;
             case "Easy":

--- a/src/features/playersSlice.tsx
+++ b/src/features/playersSlice.tsx
@@ -128,8 +128,6 @@ const playersSlice = createSlice({
                     }
                 }
 
-                console.log(newHighestLevelPlayer.level);
-
                 state.highestPlayerLevel = newHighestLevelPlayer.level
             } else {
                 state.highestPlayerLevel = 0;

--- a/src/features/playersSlice.tsx
+++ b/src/features/playersSlice.tsx
@@ -5,8 +5,7 @@ interface XPThreshhold {
     easy:number;
     medium:number,
     hard:number,
-    deadly:number,
-    
+    deadly:number,  
 }
 
 interface player {
@@ -25,6 +24,7 @@ interface PlayersState {
     hardThreshold:number,
     deadlyThreshold:number,
     targetPlayerIndex:number | null,
+    highestPlayerLevel:number,
 }
 
 
@@ -36,7 +36,8 @@ const initialState = {
     mediumThreshold:0,
     hardThreshold:0,
     deadlyThreshold:0,
-    targetPlayerIndex:null
+    targetPlayerIndex:null,
+    highestPlayerLevel:0,
 
 } as PlayersState;
 
@@ -113,6 +114,29 @@ const playersSlice = createSlice({
         setDeadlyThreshhold(state,action){
             state.deadlyThreshold = action.payload;
         },
+        changeHighestPlayerLevel(state,action){
+            state.highestPlayerLevel = action.payload;
+        },
+        findNextHighestPlayer(state) {
+
+            if (state.players.length !== 0) {
+                let newHighestLevelPlayer = state.players[0];
+
+                for (let i = 1; i < state.players.length; i++) {
+                    if (state.players[i].level > newHighestLevelPlayer.level) {
+                        newHighestLevelPlayer = state.players[i];
+                    }
+                }
+
+                console.log(newHighestLevelPlayer.level);
+
+                state.highestPlayerLevel = newHighestLevelPlayer.level
+            } else {
+                state.highestPlayerLevel = 0;
+            }
+
+
+        },
     },
 })
 
@@ -125,6 +149,7 @@ export const selectMediumThreshhold = (state: { players: { mediumThreshold: numb
 export const selectHardThreshhold = (state: { players: { hardThreshold: number; }; }) => state.players.hardThreshold;
 export const selectDeadlyThreshhold = (state: { players: { deadlyThreshold: number; }; }) => state.players.deadlyThreshold;
 export const selectEncounterDifficulty = (state: { players: { encounterDifficulty: string; }; }) => state.players.encounterDifficulty;
+export const selectHighestPlayerLevel = (state: { players: { highestPlayerLevel: number; }; }) => state.players.highestPlayerLevel;
 
 export const {
                 addPlayer,
@@ -139,6 +164,8 @@ export const {
                 setMediumThreshhold,
                 setHardThreshhold,
                 setDeadlyThreshhold,
+                changeHighestPlayerLevel,
+                findNextHighestPlayer,
             } = playersSlice.actions;
             
 export default playersSlice.reducer;


### PR DESCRIPTION
### What?
Challenge rating is now defaulted to the highest level player in the party.  It is updated when a player is added or removed from the party. Also added a display to show the user who is the highest level player in the party. 

### Why?
When a dungeon master builds an encounter, it is best not add any monsters higher than the highest level player. This will automatically suggest monsters level based on the highest level player. 

### How?
Determining the highest level player is based on to points of interaction. 

- when a player is added
- when a player is removed

When a player is first added, that players level becomes the highest level player. Then when another is added their level compared to that level. 

When a player is removed, a for loop is used to cycle through the array to see who is the highest level player. 